### PR TITLE
fix mistake related to older mbed implementation

### DIFF
--- a/src/HIDMouse.cpp
+++ b/src/HIDMouse.cpp
@@ -157,7 +157,7 @@ HIDMouse::HIDMouse(BLE &ble): BLEMouse(ble),
     
 
         ble_error_t error = _ble.gap().setAdvertisingParameters(
-            GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED,
+            ble::advertising_type_t::CONNECTABLE_UNDIRECTED,
             adv_parameters
         );
 


### PR DESCRIPTION
Tested with Arduino 15. I could connect using nRF on Android phone.
 But I do not see the BLE device on MacOS x64 (MBP 2013).
